### PR TITLE
Remove print.

### DIFF
--- a/stream/client.py
+++ b/stream/client.py
@@ -149,7 +149,6 @@ class StreamClient(object):
             payload['feed_id'] = feed_id
         if user_id is not None:
             payload['user_id'] = user_id
-        print payload
         return jwt.encode(payload, self.api_secret)
 
     def _make_request(self, method, relative_url, signature, params=None, data=None):


### PR DESCRIPTION
I assume this `print` was not intentional. (It also breaks the Python 3 compatibility.)