### PR TITLE
Use synchronous endpoint for tests and fix some of them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.7
   - 3.3
   - 3.4
+cache: pip
 notifications:
   email:
     - thierryschellenbach@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
 install:
   - pip install -r dev_requirements.txt
 script:
-  - py.test stream/tests.py -slv --cov stream --cov-report term-missing
+  - py.test stream/tests.py -lv --cov stream --cov-report term-missing
 after_script:
   # ensure we validate against pep standards
   - "pep8 --exclude=migrations --ignore=E501,E225,W293 stream"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,21 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  # These are allowed to fail
+  - '3.5-dev' # 3.5 development branch
+  - '3.6-dev' # 3.6 development branch
+  - 'nightly' # currently points to 3.7-dev
+  - 'pypy'
+  - 'pypy3'
+
+matrix:
+  allow_failures:
+    - python: '3.5-dev' # 3.5 development branch
+    - python: '3.6-dev' # 3.6 development branch
+    - python: 'nightly'
+    - python: 'pypy'
+    - python: 'pypy3'
+
 cache: pip
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ notifications:
     - thierryschellenbach@gmail.com
     - tbarbugli@gmail.com
 
-env:
-  secure: G4nELnequtvrwsK0waSmkeikVaF+HSeLgeoM2F8eN22vo92VZKrnz9r0zinBnX/VHGEJ3yNmrQ+XbStb9UuWUL9S23iy/KF2M+f0NbSHsD3iNCuCYCa6c2bQ9O9EjV3NJljXDzJgRCX3UkHq3jueLfx6rXP3Pdhz9FIUhg2F8Ok=
-  secure: M2XYAJE6WQkhcAtj7W3DMcVH4B9N82JyhTYhABXw4qpmhDEeIO5sJWodkoIKmh+nnWnbY0S6lubk6kcs8OwKk4/YMCbIcZ7iyDCJFwT6kyEwIiGyQ3YZkpwZvF5pWyxga78WgH3snTDnx1d6w5MwrKN5c5jsDpm70vrVxT0BT0U=
 install:
   - pip install -r dev_requirements.txt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
 cache: pip
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ python:
   - 'pypy3'
 
 matrix:
+  fast_finish: true
   allow_failures:
     - python: '3.5-dev' # 3.5 development branch
     - python: '3.6-dev' # 3.6 development branch

--- a/stream/__init__.py
+++ b/stream/__init__.py
@@ -11,7 +11,8 @@ __email__ = 'support@getstream.io'
 __status__ = 'Production'
 
 
-def connect(api_key=None, api_secret=None, app_id=None, version='v1.0', timeout=3.0, location=None):
+def connect(api_key=None, api_secret=None, app_id=None, version='v1.0',
+            timeout=3.0, location=None, base_url=None):
     '''
     Returns a Client object
 
@@ -32,4 +33,5 @@ def connect(api_key=None, api_secret=None, app_id=None, version='v1.0', timeout=
         else:
             raise ValueError('Invalid api key or heroku url')
 
-    return StreamClient(api_key, api_secret, app_id, version, timeout, location=location)
+    return StreamClient(api_key, api_secret, app_id, version, timeout,
+                        location=location, base_url=base_url)

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -40,8 +40,8 @@ def connect_debug():
         key,
         secret,
         location='us-east',
-        timeout=10,
-        base_url='http://qa-api.getstream.io:82/api/',
+        timeout=30,
+        base_url='http://qa-api.getstream.io/api/',
     )
 
 client = connect_debug()

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -571,15 +571,19 @@ class ClientTest(TestCase):
     def test_mark_read(self):
         notification_feed = getfeed('notification', 'py3')
         activity_data = {'actor': 1, 'verb': 'tweet', 'object': 1}
-        notification_feed.add_activity(activity_data)
+        print(notification_feed.add_activity(activity_data)['id'])
         activity_data = {'actor': 2, 'verb': 'add', 'object': 2}
-        notification_feed.add_activity(activity_data)
+        print(notification_feed.add_activity(activity_data)['id'])
         activity_data = {'actor': 3, 'verb': 'watch', 'object': 2}
-        notification_feed.add_activity(activity_data)
+        print(notification_feed.add_activity(activity_data)['id'])
 
 
         activities = notification_feed.get(limit=3)['results']
+        from pprint import pprint
+        print(len(activities))
+        pprint(activities)
         for activity in activities:
+            pprint(activity)
             self.assertFalse(activity['is_read'])
         activities = notification_feed.get(mark_read=True)['results']
         activities = notification_feed.get(limit=2)['results']
@@ -588,13 +592,17 @@ class ClientTest(TestCase):
 
     def test_get_not_marked_seen(self):
         notification_feed = getfeed('notification', 'test_mark_seen')
-        notification_feed.add_activity({'actor': 1, 'verb': 'tweet', 'object': 1})
-        notification_feed.add_activity({'actor': 2, 'verb': 'add', 'object': 2})
-        notification_feed.add_activity({'actor': 3, 'verb': 'watch', 'object': 3})
+        print(notification_feed.add_activity({'actor': 1, 'verb': 'tweet', 'object': 1})['id'])
+        print(notification_feed.add_activity({'actor': 2, 'verb': 'tweet', 'object': 2})['id'])
+        print(notification_feed.add_activity({'actor': 3, 'verb': 'tweet', 'object': 3})['id'])
 
 
         activities = notification_feed.get(limit=3)['results']
+        from pprint import pprint
+        print(len(activities))
+        pprint(activities)
         for activity in activities:
+            pprint(activity)
             self.assertFalse(activity['is_seen'])
 
     def test_mark_seen_on_get(self):
@@ -632,14 +640,18 @@ class ClientTest(TestCase):
 
     def test_mark_read_by_id(self):
         notification_feed = getfeed('notification', 'py2')
-        notification_feed.add_activity({'actor': 1, 'verb': 'tweet', 'object': 1})  # ['id']
-        notification_feed.add_activity({'actor': 2, 'verb': 'add', 'object': 2})  # ['id']
-        notification_feed.add_activity({'actor': 3, 'verb': 'watch', 'object': 2})  # ['id']
+        print(notification_feed.add_activity({'actor': 1, 'verb': 'tweet', 'object': 1})['id'])  # ['id']
+        print(notification_feed.add_activity({'actor': 2, 'verb': 'tweet', 'object': 2})['id'])  # ['id']
+        print(notification_feed.add_activity({'actor': 3, 'verb': 'tweet', 'object': 2})['id'])  # ['id']
 
 
         activities = notification_feed.get(limit=3)['results']
         ids = []
+        from pprint import pprint
+        print(len(activities))
+        pprint(activities)
         for activity in activities:
+            pprint(activity)
             ids.append(activity['id'])
             self.assertFalse(activity['is_read'])
         ids = ids[:2]

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -319,10 +319,15 @@ class ClientTest(TestCase):
 
     def test_remove_activity(self):
         activity_data = {'actor': 1, 'verb': 'tweet', 'object': 1}
+
         activity_id = self.user1.add_activity(activity_data)['id']
+        activities = self.user1.get(limit=8)['results']
+        self.assertEqual(len(activities), 1)
+
         self.user1.remove_activity(activity_id)
-        activities = self.user1.get(limit=1)['results']
-        self.assertNotEqual(activities[0]['id'], activity_id)
+        # verify that no activities were returned
+        activities = self.user1.get(limit=8)['results']
+        self.assertEqual(len(activities), 0)
 
     def test_remove_activity_by_foreign_id(self):
         activity_data = {

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -77,6 +77,12 @@ class ClientTest(TestCase):
         self.aggregated3 = aggregated3
         self.topic1 = topic1
         self.flat3 = flat3
+        print(user1.id)
+        print(user2.id)
+        print(aggregated2.id)
+        print(aggregated3.id)
+        print(topic1.id)
+        print(flat3.id)
 
         self.local_tests = False
         if 'LOCAL' in os.environ:

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -37,7 +37,8 @@ def connect_debug():
         key,
         secret,
         location='us-east',
-        timeout=10
+        timeout=10,
+        base_url='http://qa.getstream.io:82/api/',
     )
 
 random_postfix = str(int(time.time())) + str(random.randint(0, 1000))

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -16,6 +16,7 @@ import requests
 from stream import serializer
 from requests.exceptions import MissingSchema
 from itertools import count
+from uuid import uuid4
 
 try:
     from urlparse import urlparse, parse_qs
@@ -46,18 +47,18 @@ def connect_debug():
 client = connect_debug()
 
 counter = count()
-test_timestamp = int(time.time())
+test_identifier = uuid4()
 
 
-def get_random_postfix():
-    return '---test_%s-feed_%s' % (test_timestamp, next(counter))
+def get_unique_postfix():
+    return '---test_%s-feed_%s' % (test_identifier, next(counter))
 
 
 def getfeed(feed_slug, user_id):
     '''
     Adds the random postfix to the user id
     '''
-    return client.feed(feed_slug, user_id + get_random_postfix())
+    return client.feed(feed_slug, user_id + get_unique_postfix())
 
 
 class ClientTest(TestCase):
@@ -709,7 +710,7 @@ class ClientTest(TestCase):
         self.flat3.follow('user', self.user1.user_id)
         # add the same activity twice
         now = datetime.datetime.now(tzlocal())
-        tweet = 'My Way %s' % get_random_postfix()
+        tweet = 'My Way %s' % get_unique_postfix()
         activity_data = {
             'actor': 1, 'verb': 'tweet', 'object': 1, 'time': now, 'tweet': tweet}
         self.topic1.add_activity(activity_data)

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -14,6 +14,7 @@ import copy
 import requests
 from stream import serializer
 from requests.exceptions import MissingSchema
+from itertools import count
 
 try:
     from urlparse import urlparse, parse_qs
@@ -43,8 +44,13 @@ def connect_debug():
 
 client = connect_debug()
 
+counter = count()
+test_timestamp = int(time.time())
+
+
 def get_random_postfix():
-    return str(int(time.time())) + str(random.randint(0, 1000))
+    return 'test_%s-feed_%s' % (test_timestamp, next(counter))
+
 
 def getfeed(feed_slug, user_id):
     '''

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -721,7 +721,7 @@ class ClientTest(TestCase):
         # the second post should have overwritten the first one (because they
         # had same id)
 
-        self.assertEqual(len(activities['foreign_id']), 1)
+        self.assertEqual(len(activities), 1)
         self.assertEqual(activities[0]['object'], '3')
         self.assertEqual(activities[0]['foreign_id'], 'tweet:11')
         self.assertDatetimeAlmostEqual(activities[0]['time'], utcnow)

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -49,7 +49,7 @@ test_timestamp = int(time.time())
 
 
 def get_random_postfix():
-    return 'test_%s-feed_%s' % (test_timestamp, next(counter))
+    return '---test_%s-feed_%s' % (test_timestamp, next(counter))
 
 
 def getfeed(feed_slug, user_id):

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -357,7 +357,12 @@ class ClientTest(TestCase):
         self.assertEqual(get_activity_ids, activity_ids[::-1])
 
     def test_add_activities_to(self):
-        to = [getfeed('user', 'pyto2').id, getfeed('user', 'pyto3').id]
+        pyto2 = getfeed('user', 'pyto2')
+        pyto3 = getfeed('user', 'pyto3')
+        print(pyto2.id)
+        print(pyto3.id)
+
+        to = [pyto2.id, pyto3.id]
         activity_data = [
             {'actor': 1, 'verb': 'tweet', 'object': 1, 'to': to},
             {'actor': 2, 'verb': 'watch', 'object': 2, 'to': to},
@@ -368,13 +373,11 @@ class ClientTest(TestCase):
         get_activity_ids = [a['id'] for a in activities]
         self.assertEqual(get_activity_ids, activity_ids[::-1])
         # test first target
-        feed = getfeed('user', 'pyto2')
-        activities = feed.get(limit=2)['results']
+        activities = pyto2.get(limit=2)['results']
         get_activity_ids = [a['id'] for a in activities]
         self.assertEqual(get_activity_ids, activity_ids[::-1])
         # test second target
-        feed = getfeed('user', 'pyto3')
-        activities = feed.get(limit=2)['results']
+        activities = pyto3.get(limit=2)['results']
         get_activity_ids = [a['id'] for a in activities]
         self.assertEqual(get_activity_ids, activity_ids[::-1])
 

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -730,6 +730,8 @@ class ClientTest(TestCase):
         # verify that flat3 contains the activity exactly once
         response = self.flat3.get(limit=3)
         activity_tweets = [a.get('tweet') for a in response['results']]
+        print(response)
+        print(activity_tweets)
         self.assertEqual(activity_tweets.count(tweet), 1)
 
     def test_uniqueness_foreign_id(self):

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -91,7 +91,10 @@ class ClientTest(TestCase):
         :param local_wait: float, number of seconds to sleep when hitting localhost API
         :return: None
         """
-        return
+        sleep_time = production_wait
+        if self.local_tests:
+            sleep_time = local_wait
+        time.sleep(sleep_time)
 
     def test_update_activities_create(self):
         activities = [{

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -127,7 +127,6 @@ class ClientTest(TestCase):
         activities_created = self.user1.add_activities(activities)['activities']
         activities = copy.deepcopy(activities_created)
 
-        self._test_sleep(3, 0.25)
 
         for activity in activities:
             activity.pop('id')
@@ -245,7 +244,6 @@ class ClientTest(TestCase):
         activity_data['to'] = [team_feed.id]
         feed.add_activity(activity_data)
 
-        self._test_sleep(2, 0.25)
 
         self.assertEqual(activity_data['to'], [team_feed.id])
 
@@ -256,7 +254,6 @@ class ClientTest(TestCase):
         activity_data['to'] = [team_feed.id]
         feed.add_activities([activity_data])
 
-        self._test_sleep(2, 0.25)
 
         self.assertEqual(activity_data['to'], [team_feed.id])
 
@@ -272,7 +269,6 @@ class ClientTest(TestCase):
         response = user_feed.add_activity(activity_data)
         activity_id = response['id']
 
-        self._test_sleep(2, 0.25)
 
         # see if the new activity is also in the team feed
         activities = team_feed.get(limit=1)['results']
@@ -318,7 +314,6 @@ class ClientTest(TestCase):
         activity_data = {'actor': 1, 'verb': 'tweet', 'object': 1}
         activity_id = self.user1.add_activity(activity_data)['id']
         self.user1.remove_activity(activity_id)
-        self._test_sleep(10, 0.25)
         activities = self.user1.get(limit=1)['results']
         self.assertNotEqual(activities[0]['id'], activity_id)
 
@@ -327,7 +322,6 @@ class ClientTest(TestCase):
             'actor': 1, 'verb': 'tweet', 'object': 1, 'foreign_id': 'tweet:10'}
         activity_id = self.user1.add_activity(activity_data)['id']
         self.user1.remove_activity(foreign_id='tweet:10')
-        self._test_sleep(10, 0.25)
         activities = self.user1.get(limit=1)['results']
         self.assertNotEqual(activities[0]['id'], activity_id)
         # verify this doesnt raise an error, but fails silently
@@ -374,7 +368,6 @@ class ClientTest(TestCase):
         activity_id = feed.add_activity(activity_data)['id']
         agg_feed.follow(feed.slug, feed.user_id)
 
-        self._test_sleep(5, 0.1)
 
         activities = agg_feed.get(limit=3)['results']
         activity = self._get_first_aggregated_activity(activities)
@@ -389,7 +382,6 @@ class ClientTest(TestCase):
         feed1.add_activity({ 'actor': actor_id, 'verb': 'tweet', 'object': 1 })
         feed.follow(feed1.slug, feed1.user_id, activity_copy_limit=0)
 
-        self._test_sleep(5, 0.25)
 
         activities = feed.get(limit=5)['results']
 
@@ -402,23 +394,14 @@ class ClientTest(TestCase):
         activity_data = {'actor': actor_id, 'verb': 'tweet', 'object': 1}
         activity_id = user_feed.add_activity(activity_data)['id']
 
-        self._test_sleep(10, 0.25)
 
         agg_feed.follow(user_feed.slug, user_feed.user_id)
         user_feed.remove_activity(activity_id)
 
-        for x in range(40):
-            activities = agg_feed.get(limit=3)['results']
-            activity = self._get_first_aggregated_activity(activities)
-            activity_id_found = (activity['id'] if activity is not None
-                                 else None)
-
-            try:
-                self.assertNotEqual(activity_id_found, activity_id)
-            except AssertionError:
-                self._test_sleep(1, 0.1)
-            else:
-                break
+        activities = agg_feed.get(limit=3)['results']
+        activity = self._get_first_aggregated_activity(activities)
+        activity_id_found = (activity['id'] if activity is not None
+                             else None)
 
         self.assertNotEqual(activity_id_found, activity_id)
 
@@ -429,7 +412,6 @@ class ClientTest(TestCase):
     #     activity_data = {'actor': actor_id, 'verb': 'tweet', 'object': 1}
     #     activity_id = feed.add_activity(activity_data)['id']
     #     agg_feed.follow(feed.slug, feed.user_id)
-    #     time._test_sleep(10, 0.25)
     #     activities = agg_feed.get(limit=3)['results']
     #     activity = self._get_first_aggregated_activity(activities)
     #     activity_id_found = activity['id'] if activity is not None else None
@@ -441,7 +423,6 @@ class ClientTest(TestCase):
         activity_id = feed.add_activity(activity_data)['id']
         self.flat3.follow(feed.slug, feed.user_id)
 
-        self._test_sleep(5, 0.25)
 
         activities = self.flat3.get(limit=3)['results']
         activity = self._get_first_activity(activities)
@@ -455,7 +436,6 @@ class ClientTest(TestCase):
         feed.add_activity(activity_data)['id']
         follower.follow(feed.slug, feed.user_id, activity_copy_limit=0)
 
-        self._test_sleep(5, 0.25)
 
         activities = follower.get(limit=3)['results']
         self.assertEqual(activities, [])
@@ -469,7 +449,6 @@ class ClientTest(TestCase):
         feed.add_activity(activity_data)['id']
         follower.follow(feed.slug, feed.user_id, activity_copy_limit=1)
 
-        self._test_sleep(5, 0.25)
 
         activities = follower.get(limit=3)['results']
         # verify we get the latest activity
@@ -576,7 +555,6 @@ class ClientTest(TestCase):
         activity_data = {'actor': 3, 'verb': 'watch', 'object': 2}
         notification_feed.add_activity(activity_data)
 
-        self._test_sleep(10, 0.25)
 
         activities = notification_feed.get(limit=3)['results']
         for activity in activities:
@@ -592,7 +570,6 @@ class ClientTest(TestCase):
         notification_feed.add_activity({'actor': 2, 'verb': 'add', 'object': 2})
         notification_feed.add_activity({'actor': 3, 'verb': 'watch', 'object': 3})
 
-        self._test_sleep(10, 0.25)
 
         activities = notification_feed.get(limit=3)['results']
         for activity in activities:
@@ -604,7 +581,6 @@ class ClientTest(TestCase):
         for activity in activities:
             notification_feed.remove_activity(activity['id'])
 
-        self._test_sleep(10, 0.25)
 
         old_activities = [
             notification_feed.add_activity({'actor': 1, 'verb': 'tweet', 'object': 1}),
@@ -612,10 +588,8 @@ class ClientTest(TestCase):
             notification_feed.add_activity({'actor': 3, 'verb': 'watch', 'object': 3}),
         ]
 
-        self._test_sleep(10, 2)
         notification_feed.get(mark_seen=[old_activities[0]['id'], old_activities[1]['id']])
 
-        self._test_sleep(10, 0.25)
         activities = notification_feed.get(limit=3)['results']
 
         # is the seen state correct
@@ -630,7 +604,6 @@ class ClientTest(TestCase):
 
         # see if the state properly resets after we add another activity
         notification_feed.add_activity({'actor': 3, 'verb': 'watch', 'object': 3})  # ['id']
-        self._test_sleep(10, 0.25)
         activities = notification_feed.get(limit=3)['results']
         self.assertFalse(activities[0]['is_seen'])
         self.assertEqual(len(activities[0]['activities']), 2)
@@ -641,7 +614,6 @@ class ClientTest(TestCase):
         notification_feed.add_activity({'actor': 2, 'verb': 'add', 'object': 2})  # ['id']
         notification_feed.add_activity({'actor': 3, 'verb': 'watch', 'object': 2})  # ['id']
 
-        self._test_sleep(10, 0.25)
 
         activities = notification_feed.get(limit=3)['results']
         ids = []
@@ -699,7 +671,6 @@ class ClientTest(TestCase):
         response = self.user1.add_activity(activity_data)
         response = self.user1.add_activity(activity_data)
 
-        self._test_sleep(5, 0.25)
 
         activities = self.user1.get(limit=2)['results']
         self.assertDatetimeAlmostEqual(activities[0]['time'], utcnow)
@@ -754,7 +725,6 @@ class ClientTest(TestCase):
         now = datetime.datetime.utcnow
         feed = self.user2
         for index, activity_time in enumerate([None, now, None]):
-            self._test_sleep(1, 0.1)
             if activity_time is not None:
                 activity_time = activity_time()
                 middle = activity_time
@@ -843,7 +813,6 @@ class ClientTest(TestCase):
         }
         for feed in targets:
             feed.add_activity(activity)
-            self._test_sleep(1, 0.1)
             self.assertEqual(len(feed.get(limit=5)['results']), 1)
 
         sources_id = [feed.id for feed in sources]
@@ -851,7 +820,6 @@ class ClientTest(TestCase):
         feeds = [{'source': s, 'target': t} for s, t in zip(sources_id, targets_id)]
 
         self.c.follow_many(feeds, activity_copy_limit=0)
-        self._test_sleep(5, 2)
 
         for feed in sources:
             activities = feed.get(limit=5)['results']
@@ -862,7 +830,6 @@ class ClientTest(TestCase):
         feeds = [getfeed('flat', str(i)).id for i in range(10, 20)]
         self.c.add_to_many(activity, feeds)
 
-        self._test_sleep(3, 0.25)
 
         for feed in feeds:
             feed = self.c.feed(*feed.split(':'))

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -84,10 +84,7 @@ class ClientTest(TestCase):
         :param local_wait: float, number of seconds to sleep when hitting localhost API
         :return: None
         """
-        sleep_time = production_wait
-        if self.local_tests:
-            sleep_time = local_wait
-        time.sleep(sleep_time)
+        return
 
     def test_update_activities_create(self):
         activities = [{

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -327,10 +327,16 @@ class ClientTest(TestCase):
     def test_remove_activity_by_foreign_id(self):
         activity_data = {
             'actor': 1, 'verb': 'tweet', 'object': 1, 'foreign_id': 'tweet:10'}
-        activity_id = self.user1.add_activity(activity_data)['id']
+
+        self.user1.add_activity(activity_data)['id']
+        activities = self.user1.get(limit=8)['results']
+        self.assertEqual(len(activities), 1)
+
         self.user1.remove_activity(foreign_id='tweet:10')
-        activities = self.user1.get(limit=1)['results']
-        self.assertNotEqual(activities[0]['id'], activity_id)
+        # verify that no activities were returned
+        activities = self.user1.get(limit=8)['results']
+        self.assertEqual(len(activities), 0)
+
         # verify this doesnt raise an error, but fails silently
         self.user1.remove_activity(foreign_id='tweet:unknowandmissing')
 

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -41,28 +41,29 @@ def connect_debug():
         base_url='http://qa.getstream.io:82/api/',
     )
 
-random_postfix = str(int(time.time())) + str(random.randint(0, 1000))
 client = connect_debug()
 
+def get_random_postfix():
+    return str(int(time.time())) + str(random.randint(0, 1000))
 
 def getfeed(feed_slug, user_id):
     '''
     Adds the random postfix to the user id
     '''
-    return client.feed(feed_slug, user_id + random_postfix)
-
-user1 = getfeed('user', '1')
-user2 = getfeed('user', '2')
-aggregated2 = getfeed('aggregated', '2')
-aggregated3 = getfeed('aggregated', '3')
-topic1 = getfeed('topic', '1')
-flat3 = getfeed('flat', '3')
+    return client.feed(feed_slug, user_id + get_random_postfix())
 
 
 class ClientTest(TestCase):
 
     def setUp(self):
         # DEBUG account details
+        user1 = getfeed('user', '1')
+        user2 = getfeed('user', '2')
+        aggregated2 = getfeed('aggregated', '2')
+        aggregated3 = getfeed('aggregated', '3')
+        topic1 = getfeed('topic', '1')
+        flat3 = getfeed('flat', '3')
+
         self.c = client
         self.user1 = user1
         self.user2 = user2
@@ -114,7 +115,7 @@ class ClientTest(TestCase):
                 'foreign_id': 'object:%s' % i,
                 'time': datetime.datetime.utcnow().isoformat()
             })
-        activities_created = user1.add_activities(activities)['activities']
+        activities_created = self.user1.add_activities(activities)['activities']
         activities = copy.deepcopy(activities_created)
 
         self._test_sleep(3, 0.25)
@@ -125,7 +126,7 @@ class ClientTest(TestCase):
 
         self.c.update_activities(activities)
 
-        activities_updated = user1.get(limit=len(activities))['results']
+        activities_updated = self.user1.get(limit=len(activities))['results']
         activities_updated.reverse()
 
         for i, activity in enumerate(activities_updated):
@@ -707,7 +708,7 @@ class ClientTest(TestCase):
         self.flat3.follow('user', self.user1.user_id)
         # add the same activity twice
         now = datetime.datetime.now(tzlocal())
-        tweet = 'My Way %s' % random_postfix
+        tweet = 'My Way %s' % get_random_postfix()
         activity_data = {
             'actor': 1, 'verb': 'tweet', 'object': 1, 'time': now, 'tweet': tweet}
         self.topic1.add_activity(activity_data)

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -701,19 +701,23 @@ class ClientTest(TestCase):
     def test_uniqueness_foreign_id(self):
         now = datetime.datetime.now(tzlocal())
         utcnow = (now - now.utcoffset()).replace(tzinfo=None)
+
         activity_data = {'actor': 1, 'verb': 'tweet',
                          'object': 1, 'foreign_id': 'tweet:11', 'time': now}
         response = self.user1.add_activity(activity_data)
+
         activity_data = {'actor': 2, 'verb': 'tweet',
                          'object': 3, 'foreign_id': 'tweet:11', 'time': now}
         response = self.user1.add_activity(activity_data)
-        activities = self.user1.get(limit=2)['results']
+
+        activities = self.user1.get(limit=10)['results']
         # the second post should have overwritten the first one (because they
         # had same id)
+
+        self.assertEqual(len(activities['foreign_id']), 1)
         self.assertEqual(activities[0]['object'], '3')
         self.assertEqual(activities[0]['foreign_id'], 'tweet:11')
         self.assertDatetimeAlmostEqual(activities[0]['time'], utcnow)
-        self.assertNotEqual(activities[1]['foreign_id'], 'tweet:11')
 
     def test_time_ordering(self):
         '''

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -39,7 +39,7 @@ def connect_debug():
         secret,
         location='us-east',
         timeout=10,
-        base_url='http://qa.getstream.io:82/api/',
+        base_url='http://qa-api.getstream.io:82/api/',
     )
 
 client = connect_debug()


### PR DESCRIPTION
The only ones that are still failing are the mark_read and mark_seen tests. These can fail randomly on the QA server, but don't seem to do so on the regular one.