### PR TITLE
Fix error message code for errors with exception_fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,15 @@
  Change history
 ================
 
+Unreleased
+==========
+:release-date: YYYY-MM-DD
+:by: Unknown
+
+* Fix errors_from_fields function so it displays the extra data returned by the
+    server about InputException errors.
+
+
 2.3.8
 =====
 :release-date: 2016-06-09

--- a/stream/client.py
+++ b/stream/client.py
@@ -184,7 +184,7 @@ class StreamClient(object):
                 return exception_fields
 
             for field, errors in exception_fields.items():
-                errors.append('Field "%s" errors: %s' % (field, repr(errors)))
+                result.append('Field "%s" errors: %s' % (field, repr(errors)))
             return result
 
         if result is not None:

--- a/stream/client.py
+++ b/stream/client.py
@@ -180,7 +180,7 @@ class StreamClient(object):
 
         def errors_from_fields(exception_fields):
             result = []
-            if not isinstance(exception_fields, list):
+            if not isinstance(exception_fields, dict):
                 return exception_fields
 
             for field, errors in exception_fields.items():


### PR DESCRIPTION
The code contained two stupid mistakes that caused the full error message not
to be displayed.