### PR TITLE
Enable SNI support for old python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - '3.5-dev' # 3.5 development branch
   - '3.6-dev' # 3.6 development branch
   - 'nightly' # currently points to 3.7-dev
-  - 'pypy'
+  - 'pypy-5.3.1'
   - 'pypy3'
 
 matrix:
@@ -19,7 +19,7 @@ matrix:
     - python: '3.5-dev' # 3.5 development branch
     - python: '3.6-dev' # 3.6 development branch
     - python: 'nightly'
-    - python: 'pypy'
+    - python: 'pypy-5.3.1'
     - python: 'pypy3'
 
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 python:
+  - '2.7.8'
   - 2.7
   - 3.3
   - 3.4

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,15 @@
  Change history
 ================
 
+2.3.10
+==========
+:release-date: xxxx-yy-zz
+:by: <Unknown>
+
+* Require requests[security] for python versions below 2.7.9 this is required
+    for SNI support.
+
+
 2.3.9
 ==========
 :release-date: 2016-12-20

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,12 @@ Full documentation is available on `Github`_.
 .. _`Github`: https://github.com/GetStream/stream-python
 '''
 
+requests = 'requests[security]>=2.3.0' if sys.version_info < (2, 7, 9) else (
+    'requests>=2.3.0')
+
 install_requires = [
     'pyjwt==1.3.0',
-    'requests>=2.3.0',
+    requests,
     'six>=1.8.0',
     'httpsig==1.1.2'
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,13 @@ Full documentation is available on `Github`_.
 .. _`Github`: https://github.com/GetStream/stream-python
 '''
 
-requests = 'requests[security]>=2.4.1' if sys.version_info < (2, 7, 9) else (
-    'requests>=2.3.0')
+requests = 'requests[security]>=2.4.1,<3' if sys.version_info < (2, 7, 9) else (
+    'requests>=2.3.0,<3')
 
 install_requires = [
     'pyjwt==1.3.0',
     requests,
-    'six>=1.8.0',
+    'six>=1.8.0,<2',
     'httpsig==1.1.2'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ Full documentation is available on `Github`_.
 .. _`Github`: https://github.com/GetStream/stream-python
 '''
 
-requests = 'requests[security]>=2.3.0' if sys.version_info < (2, 7, 9) else (
+requests = 'requests[security]>=2.4.1' if sys.version_info < (2, 7, 9) else (
     'requests>=2.3.0')
 
 install_requires = [

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -41,7 +41,7 @@ def connect_debug():
         secret,
         location='us-east',
         timeout=30,
-        base_url='http://qa-api.getstream.io/api/',
+        base_url='https://geo.getstream.io/api/',
     )
 
 client = connect_debug()

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -41,7 +41,7 @@ def connect_debug():
         secret,
         location='us-east',
         timeout=30,
-        base_url='https://geo.getstream.io/api/',
+        base_url='https://sni-api.getstream.io/api/',
     )
 
 client = connect_debug()


### PR DESCRIPTION
## Summary:

We are thinking about using SNI for our certificates. This enables support for
that on python versions lower than 2.7.9.

It also requires requests of at least version 2.4.1 for these python versions. This is because here the security extra is added that is used to pull in the SNI deps. These deps differ from requests release to requests release so they cannot be added manually easily. 


## Submitter checklist:
- [x] `CHANGELOG` updated or N/A
- [x] Documentation updated or N/A

## Merger checklist:
- [x] ALL tests have passed
- [ ] Code Review is done
- [x] Dependencies satisfied