### PR TITLE
Travis: Update pypy3 so no tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - '3.6-dev' # 3.6 development branch
   - 'nightly' # currently points to 3.7-dev
   - 'pypy'
-  - 'pypy3'
+  - 'pypy3.3-5.2-alpha1'
 
 matrix:
   fast_finish: true
@@ -19,7 +19,7 @@ matrix:
     - python: '3.6-dev' # 3.6 development branch
     - python: 'nightly'
     - python: 'pypy'
-    - python: 'pypy3'
+    - python: 'pypy3.3-5.2-alpha1'
 
 cache: pip
 notifications:


### PR DESCRIPTION
## Summary:

This is a more recent pypy3 release that is python 3.3 compatible instead
of 3.2 compatible.
This fixes the failure in the tests.


## Submitter checklist:
- [x] `CHANGELOG` updated or N/A
- [x] Documentation updated or N/A

## Merger checklist:
- [x] ALL tests have passed
- [ ] Code Review is done
- [x] Dependencies satisfied