### PR TITLE
Calling self._make_signed_request should return the response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,13 @@
  Change history
 ================
 
+2.6.0
+======
+:release-date: ??
+:by: Aaron McMillin
+
+* All client methods that make requests will return the response
+
 2.5.0
 ======
 :release-date: 2017-10-19

--- a/stream/client.py
+++ b/stream/client.py
@@ -236,7 +236,7 @@ class StreamClient(object):
 
         '''
         data = {'activity': activity, 'feeds': feeds}
-        self._make_signed_request('post', 'feed/add_to_many/', data=data)
+        return self._make_signed_request('post', 'feed/add_to_many/', data=data)
 
     def follow_many(self, follows, activity_copy_limit=None):
         '''
@@ -251,7 +251,7 @@ class StreamClient(object):
         if activity_copy_limit != None:
             params = dict(activity_copy_limit=activity_copy_limit)
 
-        self._make_signed_request('post', 'follow_many/', params=params, data=follows)
+        return self._make_signed_request('post', 'follow_many/', params=params, data=follows)
 
     def update_activities(self, activities):
         '''


### PR DESCRIPTION
## Summary:
Since _make_signed_request parses and returns the response. Any methods that call it should return the response.

## Submitter checklist:
- [x] `CHANGELOG` updated or N/A
- [ ] Documentation updated or N/A

## Merger checklist:
- [ ] ALL tests have passed
- [ ] Code Review is done
- [ ] Dependencies satisfied