### PR TITLE
Set encoding to match RFC if none is present

### DIFF
--- a/stream/client.py
+++ b/stream/client.py
@@ -133,6 +133,8 @@ class StreamClient(object):
 
     def _parse_response(self, response):
         try:
+            if response.encoding is None:
+                response.encoding = 'utf-8'
             parsed_result = serializer.loads(response.text)
         except ValueError:
             parsed_result = None

--- a/stream/tests.py
+++ b/stream/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from dateutil.tz import tzlocal
 import stream
 import time
@@ -277,6 +278,16 @@ class ClientTest(TestCase):
         activity_id = response['id']
         activities = feed.get(limit=1)['results']
         self.assertEqual(activities[0]['id'], activity_id)
+
+    def test_add_activity_with_utf8_data(self):
+        feed = getfeed('user', 'py1')
+        activity_data = {'actor': 2, 'verb': 'tweet', 'object': '😀🐶❤️'}
+        response = feed.add_activity(activity_data)
+        activity_id = response['id']
+        activity_object = response['object']
+        activities = feed.get(limit=1)['results']
+        self.assertEqual(activities[0]['id'], activity_id)
+        self.assertEqual(activities[0]['object'], activity_object)
 
     def test_add_activity_to_inplace_change(self):
         feed = getfeed('user', 'py1')


### PR DESCRIPTION
## Summary:
Since the library uses custom json parsing and not the one from requests.Response , the encoding of the data has to be ensured if it is not specified

## Merger checklist:
- [ ] ALL tests have passed
- [ ] Code Review is done
- [ ] Dependencies satisfied

