### PR TITLE
Fix datetime serialization

### DIFF
--- a/stream/serializer.py
+++ b/stream/serializer.py
@@ -4,13 +4,18 @@ import six
 
 '''
 Adds the ability to send date and datetime objects to the API
+Datetime objects will be encoded/ decoded with microseconds
 The date and datetime formats from the API are automatically supported and parsed
 '''
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
+DATE_FORMAT = "%Y-%m-%d"
 
 
 def _datetime_encoder(obj):
-    if isinstance(obj, (datetime.datetime, datetime.date)):
-        return obj.isoformat()
+    if isinstance(obj, datetime.datetime):
+        return datetime.datetime.strftime(obj, DATETIME_FORMAT)
+    if isinstance(obj, datetime.date):
+        return datetime.datetime.strftime(obj, DATE_FORMAT)
 
 
 def _datetime_decoder(dict_):
@@ -26,15 +31,13 @@ def _datetime_decoder(dict_):
             try:
                 # The api always returns times like this
                 # 2014-07-25T09:12:24.735
-                datetime_obj = datetime.datetime.strptime(
-                    value, "%Y-%m-%dT%H:%M:%S.%f")
+                datetime_obj = datetime.datetime.strptime(value, DATETIME_FORMAT)
                 dict_[key] = datetime_obj
             except (ValueError, TypeError):
                 try:
                     # The api always returns times like this
                     # 2014-07-25T09:12:24.735
-                    datetime_obj = datetime.datetime.strptime(
-                        value, "%Y-%m-%d")
+                    datetime_obj = datetime.datetime.strptime(value, DATE_FORMAT)
                     dict_[key] = datetime_obj.date()
                 except (ValueError, TypeError):
                     continue

--- a/stream/tests/test_client.py
+++ b/stream/tests/test_client.py
@@ -942,8 +942,9 @@ class ClientTest(TestCase):
 
     def test_serialization(self):
         today = datetime.date.today()
+        then = datetime.datetime.now().replace(microsecond=0)
         now = datetime.datetime.now()
-        data = dict(string="string", float=0.1, int=1, date=today, datetime=now)
+        data = dict(string="string", float=0.1, int=1, date=today, datetime=now, datetimenomicro=then)
         serialized = serializer.dumps(data)
         loaded = serializer.loads(serialized)
         self.assertEqual(data, loaded)


### PR DESCRIPTION
## Summary:
stream.py encodes dates to the Stream API using `isoformat()` which drops microseconds if they are zero. However on decoding from the Stream API, stream.py expects microseconds to exist.

In most instances, calling `datetime.now()` will provide non-zero microseconds. However where an activity is created with datetime values set by a user (from the date widget in Django's admin panel for instance), microseconds will not exist. These fields will be currently be deserialized (incorrectly) as strings by stream.py.

This PR adds extra logic to the serializer test case to verify the issue, and updates serialization to use the same string format for reading and writing datetime objects. I could have kept isoformat and specified `obj.isoformat(sep='T', timespec='microseconds')`, but that arg is only available in Python 3.6+. Instead I've used `strftime` when writing to mirror the existing use of `strptime` when reading.

## Submitter checklist:
- [ ] `CHANGELOG` updated or N/A
- [x] Documentation updated or N/A

## Merger checklist:
- [ ] ALL tests have passed
- [ ] Code Review is done
- [ ] Dependencies satisfied