### PR TITLE
avoid getting 414's that occur with large data loads getting passed a…

### DIFF
--- a/stream/personalization.py
+++ b/stream/personalization.py
@@ -42,6 +42,9 @@ class Personalization(object):
         """
 
         data = params["data"] or None
+        if data:
+            # avoid 414's by passing entire data chunk in uri
+            del params["data"]
 
         response = self.client.post(
             resource,


### PR DESCRIPTION
…s params in the uri

## Summary:
stream api returns 414's when data is passed as params in uri

## Submitter checklist:
- [ ] `CHANGELOG` updated or N/A
- [ ] Documentation updated or N/A

## Merger checklist:
- [ ] ALL tests have passed
- [ ] Code Review is done
- [ ] Dependencies satisfied

## Dependencies:
<!-- other (upstream) repos - link to other corresponding PRs/tickets, remove
section if not applicable -->
- [ ] <!-- e.g https://github.com/GetStream/stream-python/issues/40 -->
