### PR TITLE
Drop undocumented create_user_session_token

### DIFF
--- a/stream/client.py
+++ b/stream/client.py
@@ -169,16 +169,14 @@ class StreamClient(object):
         return parsed_result
 
     def create_user_token(self, user_id, **extra_data):
-        """Setup the payload for the given user_id with optional
+        """
+        Setup the payload for the given user_id with optional
         extra data (key, value pairs) and encode it using jwt
         """
         payload = {"user_id": user_id}
         for k, v in extra_data.items():
             payload[k] = v
         return jwt.encode(payload, self.api_secret, algorithm="HS256").decode("utf-8")
-
-    def create_user_session_token(self, user_id, **extra_data):
-        return self.create_user_token(user_id, **extra_data)
 
     def create_jwt_token(self, resource, action, feed_id=None, user_id=None):
         """

--- a/stream/tests/test_client.py
+++ b/stream/tests/test_client.py
@@ -373,12 +373,12 @@ class ClientTest(TestCase):
         self.user1.token
         self.user1.get_readonly_token()
 
-    def test_user_session_token(self):
+    def test_user_token(self):
         client = stream.connect(self.c.api_key, self.c.api_secret)
-        token = client.create_user_session_token("user")
+        token = client.create_user_token("user")
         payload = jwt.decode(token, self.c.api_secret, algorithms=["HS256"])
         self.assertEqual(payload["user_id"], "user")
-        token = client.create_user_session_token("user", client="python", testing=True)
+        token = client.create_user_token("user", client="python", testing=True)
         payload = jwt.decode(token, self.c.api_secret, algorithms=["HS256"])
         self.assertEqual(payload["client"], "python")
         self.assertEqual(payload["testing"], True)


### PR DESCRIPTION
This method on `client` is exactly same with `create_user_token`
and the implementation delegates to create_user_token and it is undocumented.

To keep the code clean, dropped it.