### PR TITLE
Support follow count in user get

### DIFF
--- a/stream/tests/test_client.py
+++ b/stream/tests/test_client.py
@@ -1377,6 +1377,13 @@ class ClientTest(TestCase):
         self.assertTrue("updated_at" in user)
         self.assertTrue("id" in user)
 
+    def test_user_get_with_follow_counts(self):
+        response = self.c.users.add(str(uuid1()))
+        user = self.c.users.get(response["id"], with_follow_counts=True)
+        self.assertEqual(user["id"], response["id"])
+        self.assertTrue("followers_count" in user)
+        self.assertTrue("following_count" in user)
+
     def test_user_update(self):
         response = self.c.users.add(str(uuid1()))
         self.c.users.update(response["id"], {"changed": True})

--- a/stream/users.py
+++ b/stream/users.py
@@ -19,9 +19,9 @@ class Users(object):
             params={"get_or_create": get_or_create},
         )
 
-    def get(self, user_id):
+    def get(self, user_id, **params):
         return self.client.get(
-            "user/%s" % user_id, service_name="api", signature=self.token
+            "user/%s" % user_id, service_name="api", params=params, signature=self.token
         )
 
     def update(self, user_id, data=None):


### PR DESCRIPTION
## Summary:
Add query param support in user get for follow counts.

## Submitter checklist:
- [ ] `CHANGELOG` updated or N/A
- [ ] Documentation updated or N/A

## Merger checklist:
- [ ] ALL tests have passed
- [ ] Code Review is done
- [ ] Dependencies satisfied

## Dependencies:
<!-- other (upstream) repos - link to other corresponding PRs/tickets, remove
section if not applicable -->
- [ ] <!-- e.g https://github.com/GetStream/stream-python/issues/40 -->
