### PR TITLE
Allow custom payload in `client.create_jwt_token`

### DIFF
--- a/stream/client.py
+++ b/stream/client.py
@@ -178,16 +178,12 @@ class StreamClient(object):
             payload[k] = v
         return jwt.encode(payload, self.api_secret, algorithm="HS256").decode("utf-8")
 
-    def create_jwt_token(self, resource, action, feed_id=None, user_id=None, **payload):
+    def create_jwt_token(self, resource, action, feed_id=None, user_id=None, **params):
         """
         Setup the payload for the given resource, action, feed or user
         and encode it using jwt
         """
-        if not payload:
-            payload = {"action": action, "resource": resource}
-        else:
-            payload["action"] = action
-            payload["resource"] = resource
+        payload = {**params, "action": action, "resource": resource}
         if feed_id is not None:
             payload["feed_id"] = feed_id
         if user_id is not None:

--- a/stream/client.py
+++ b/stream/client.py
@@ -178,12 +178,16 @@ class StreamClient(object):
             payload[k] = v
         return jwt.encode(payload, self.api_secret, algorithm="HS256").decode("utf-8")
 
-    def create_jwt_token(self, resource, action, feed_id=None, user_id=None):
+    def create_jwt_token(self, resource, action, feed_id=None, user_id=None, **payload):
         """
         Setup the payload for the given resource, action, feed or user
         and encode it using jwt
         """
-        payload = {"action": action, "resource": resource}
+        if not payload:
+            payload = {"action": action, "resource": resource}
+        else:
+            payload["action"] = action
+            payload["resource"] = resource
         if feed_id is not None:
             payload["feed_id"] = feed_id
         if user_id is not None:


### PR DESCRIPTION
## Summary:
Allow a custom payload when creating (server side) jwt token 

## Submitter checklist:
- [ ] `CHANGELOG` updated or N/A
- [ ] Documentation updated or N/A

## Merger checklist:
- [ ] ALL tests have passed
- [ ] Code Review is done
- [ ] Dependencies satisfied

## Dependencies:
<!-- other (upstream) repos - link to other corresponding PRs/tickets, remove
section if not applicable -->
- [ ] <!-- e.g https://github.com/GetStream/stream-python/issues/40 -->
